### PR TITLE
Add rusty clock

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -16,6 +16,13 @@
   description: "Vivamus varius cursus aliquam. Praesent scelerisque, neque efficitur luctus pharetra, augue urna tempus lectus, at ullamcorper sem purus et enim. Nam urna eros, ornare quis mi posuere, aliquam egestas turpis. Suspendisse quis mi viverra, malesuada justo ullamcorper, blandit risus"
   image: https://via.placeholder.com/900x675
 
+- name: Rusty clock
+  website: https://github.com/TeXitoi/rusty-clock
+  author: TeXitoi
+  author_website: https://github.com/TeXitoi/
+  description: An alarm clock in pure bare metal embedded rust (no OS). It features pressure, temperature, humidity, monophonic alarm on a e-paper display. The 5 programmable alarms can ring one time (and never repeat) or every week day that you want (for example only Monday and Thursday).
+  image: https://raw.githubusercontent.com/TeXitoi/rusty-clock/master/images/front.jpg
+
 # Template for new entries
 
   # Project name


### PR DESCRIPTION
Auto evaluation:

# Hard requirements

> The main logic of the application must be written in Rust.

100% rust (except ASM on the cortex-m and cortex-m-rt crates)

> The source code must be public. Licensing terms are unimportant.

On github, MIT licensed.

# Bonus points

> The project is unlike the projects currently on display.

This one is easy as I'm the first :innocent: 

> The documentation includes instructions on how to build the program, or the firmware can be built with just cargo build.

End of the README.md explain everything (and that's just `cargo build --release` to compile the firmware).

> The repository has a CI setup.

Travis build, run the unit tests and check rust-fmt.

> The application compiles on stable.

Travis tests on stable, beta and nightly.

> The application code is free from unsafe code and all unsafe code has been pushed to libraries that only expose a safe API.

There is one unsafe to clear a timer interrupt (yes, I need to upstream that).

There is also unsafe code in the dependent crate pwm-speaker. I need to upstream an embedded_hal::Pwm impl on stm32f1xx-hal to remove it.

> Code that's not target specific, if any, has unit tests.

There is some light unit tests on the `portable` subcrate (80% of the code) that contains all the code that can be run on amd64.

> Support code, if any, is documented.

I don't understand what is support code.

# Penalties

> The application contains potential soundness issues. For example, using mem::transmute, unchecked creation of singletons and unchecked use of static mut variables are huge red flags.

It's clean on this way, as explained in the unsafe section.

> Explicit panicking (e.g. unwrap) is used instead of proper error handling. However, note that unreachable! is OK if properly used.

There is quite a lot of`unwrap()`s, mainly on `heapless::Vec::push`, SPI calls and RTFM message passing.