### PR TITLE
Adding i2c hal tools project.

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -16,6 +16,12 @@
   description: "Vivamus varius cursus aliquam. Praesent scelerisque, neque efficitur luctus pharetra, augue urna tempus lectus, at ullamcorper sem purus et enim. Nam urna eros, ornare quis mi posuere, aliquam egestas turpis. Suspendisse quis mi viverra, malesuada justo ullamcorper, blandit risus"
   image: https://via.placeholder.com/900x675
 
+- name: I2c hal tools
+  website: https://github.com/mathk/i2c-hal-tools
+  author: mathk
+  author_website: https://github.com/mathk
+  description: "A small library aiming to add better abstraction when talking to i2c bus."
+
 # Template for new entries
 
   # Project name


### PR DESCRIPTION
Auto evaluation:

# Hard requirements

> The main logic of the application must be written in Rust.

100% rust

> The source code must be public. Licensing terms are unimportant.

On github licences: the on that suite best the embedded wg

# Penalties

Not yet full feature. This will serve as a way to gather feedback on useful abstraction to add