### PR TITLE
Add monotron

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -22,6 +22,11 @@
     of any size. The firmware allow you to customize each key as you wish:
     a layer change, a key combo or a regular key.
   image: https://raw.githubusercontent.com/TeXitoi/keyberon/master/images/keyberon.jpg
+- name: Monotron
+  website: https://github.com/thejpster/monotron
+  author_website: https://thejpster.org.uk/
+  description: A simple 1980's home computer style application for the Tiva-C Launchpad
+  image: https://raw.githubusercontent.com/thejpster/monotron/master/screenshot.jpg
 
 # Template for new entries
 

--- a/data.yml
+++ b/data.yml
@@ -24,6 +24,7 @@
   image: https://raw.githubusercontent.com/TeXitoi/keyberon/master/images/keyberon.jpg
 - name: Monotron
   website: https://github.com/thejpster/monotron
+  author: theJPster
   author_website: https://thejpster.org.uk/
   description: A simple 1980's home computer style application for the Tiva-C Launchpad
   image: https://raw.githubusercontent.com/thejpster/monotron/master/screenshot.jpg


### PR DESCRIPTION
As discussed in https://github.com/thejpster/monotron/issues/65 I propose to add Monotron to the embedded rust showcase. I think this project is needed in the showcase as one of the first embedded rust project.

@thejpster can you validate the content of the entry?

Hard requirement:
 - run on a Texas Instruments TM4C123 microcontroller
 - mostly rust, the base of the project is rust
 - Apache2 or MIT licensed, project on github

Bonus points:
 - Crazy things as VGA without dedicated hardware
 - Instructions to build yours is available
 - travis do a cargo build
 - nightly only project (for ASM)
 - "a massive race hazard and full of undefined behaviour"
 - no unit test as far as I know
 - some external useful crates have been created for this project as, for example, embedded-sdmmc

Penalties
 - "a massive race hazard and full of undefined behaviour"
 - Looks like there is quite a lot of unwrap.