### PR TITLE
Tell ghp-import to generate CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-showcase.rust-embedded.org

--- a/ci/after-success.sh
+++ b/ci/after-success.sh
@@ -5,7 +5,7 @@ main() {
     curl -Ls https://github.com/davisp/ghp-import/archive/master.tar.gz |
         tar --strip-components 1 -C ghp-import -xz
 
-    ./ghp-import/ghp_import.py public
+    ./ghp-import/ghp_import.py -c showcase.rust-embedded.org public
 
     # NOTE(+x) don't print $GH_TOKEN to the console!
     set +x


### PR DESCRIPTION
We added a CNAME file to the master branch in #15 but it never ended up copied into the gh-pages branch, so isn't active. Given as this build uses ghp-import right now, the simplest solution seems to be to just use its option for setting CNAME.

Same as https://github.com/rust-embedded/blog/pull/146.