### PR TITLE
Set CNAME for gh-pages build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: public
           force_orphan: true
+          cname: showcase.rust-embedded.org


### PR DESCRIPTION
Oops, #29 didn't quite nail it. The build seems OK (http://docs.rust-embedded.org/showcase/) but I forgot to set the CNAME.